### PR TITLE
Allow using a preinstalled oldgtk3

### DIFF
--- a/gintro.nimble
+++ b/gintro.nimble
@@ -31,8 +31,6 @@ proc prep =
     # quit("gintro: tmp directory already exists!")
   mkDir(wd)
   cd(wd)
-  mkDir("ngtk3")
-  cd("ngtk3")
 
   cpFile(this / "tests" / "gen.nim", td / wd / "gen.nim")
   cpFile(this / "tests" / "combinatorics.nim", td / wd / "combinatorics.nim")
@@ -40,6 +38,8 @@ proc prep =
   cd(td)
   cd(wd)
 
+  mkDir("oldgtk3")
+  cd("oldgtk3")
   try:
     exec("wget https://raw.githubusercontent.com/StefanSalewski/oldgtk3/master/oldgtk3/gobject.nim -O gobject.nim")
     exec("wget https://raw.githubusercontent.com/StefanSalewski/oldgtk3/master/oldgtk3/glib.nim -O glib.nim")
@@ -57,6 +57,7 @@ proc prep =
       echo "Nimgrab should be available in Nim/tools directory. You may compile it with 'nim c -d:ssl nimgrab.nim'"
       echo "and put it into your search path"
       echo "For the unlikely case that you have already full oldgtk3 package installed, we will just try to continue..."
+  cd("..")
 
   exec("nim c gen.nim")
   mkDir("nim_gi")
@@ -70,7 +71,6 @@ proc prep =
 
 #task prepare, "preparing gintro":
 before install:
-
   echo "preparing gintro"
   prep()
   

--- a/tests/gen.nim
+++ b/tests/gen.nim
@@ -31,8 +31,8 @@
 # This module is really ugly currently  -- the first goal was to get a working gi solution
 
 from os import `/`
-import gir
-import glib
+import oldgtk3/gir
+import oldgtk3/glib
 import strutils
 import sequtils
 import streams


### PR DESCRIPTION
This allows using a preinstalled oldgtk3 (either installed by nimble
install or manually in nimble's search paths) after the download failed.

I saw the directory ``ngtk3`` which was unused, so I guess it has already been possible in the past. I need this because I am packaging gintro for [Nix](https://nixos.org/nix/). There it is not allowed to download files during the build/install phase. So I'm installing oldgtk3 before and need nimble to use it.