### PR TITLE
fix compilation error

### DIFF
--- a/tests/gen.nim
+++ b/tests/gen.nim
@@ -733,7 +733,7 @@ proc writeMethod(info: GIBaseInfo; minfo: GIFunctionInfo; genProxy = false) =
                 else:
                   echo "Caution: No free/unref found for ", ' ', " (", sym, ')' # Mostly missing cairo functions...
               else:
-                assert not fixedDestroyNames.contains(sym)
+                assert(not fixedDestroyNames.contains(sym))
                 freeMeName = $gBaseInfoGetName(freeMe)
               if sym == "g_closure_new_simple" or sym == "g_closure_new_object": freeMeName = "unref" # TODO GI bug?
               assert(gCallableInfoGetCallerOwns(minfo) in {GITransfer.EVERYTHING, GITransfer.NOTHING})


### PR DESCRIPTION
Fixes the following compilation error (I get it with nim 0.19.4 and 0.19.6):

```nim
gen.nim(736, 24) Error: type mismatch: got <proc (cond: bool, msg: string): typed, bool>
but expected one of:
proc `not`(x: bool): bool
  first type mismatch at position: 1
  required type: bool
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`[T: SomeUnsignedInt](x: T): T
  first type mismatch at position: 1
  required type: T: SomeUnsignedInt
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`(x: int): int
  first type mismatch at position: 1
  required type: int
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`(a: typedesc): typedesc
  first type mismatch at position: 1
  required type: typedesc
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`(x: int64): int64
  first type mismatch at position: 1
  required type: int64
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`(x: int32): int32
  first type mismatch at position: 1
  required type: int32
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`(x: int8): int8
  first type mismatch at position: 1
  required type: int8
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
proc `not`(x: int16): int16
  first type mismatch at position: 1
  required type: int16
  but expression 'assert' is of type: proc (cond: bool, msg: string): typed
```