### PR TITLE
Fix tests/gen.nim so that it doesn't generate dynlib pragma with empty string

### DIFF
--- a/tests/gen.nim
+++ b/tests/gen.nim
@@ -2359,7 +2359,8 @@ proc main(namespace: string; version: cstring = nil) =
   elif namespace == "GLib":
     # we need gobject.
     let gobjectlibs = gi.gIrepositoryGetSharedLibrary("GObject")
-    var GobjectLib = if gobjectlibs.isNil: "" else: ($gobjectlibs).split(',', 2)[0]
+    doAssert not gobjectlibs.isNil
+    var GobjectLib = ($gobjectlibs).split(',', 2)[0]
     output.writeLine("const GobjectLib* = \"$1\"" % GobjectLib)
     output.writeLine("{.pragma: gobjectlibprag, cdecl, dynlib: GobjectLib.}")
 
@@ -2890,8 +2891,8 @@ proc launch() =
     main("GdkX11", "3.0")
     # main("Gsk") # not available for GTK3
     main("Graphene")
+    main("GObject") # GObject namespace must be loaded before calling main("GLib")
     main("GLib") # and the old common onces
-    main("GObject")
     main("Gio")
     main("GdkPixbuf")
     main("GModule")
@@ -2918,8 +2919,8 @@ proc launch() =
     main("GdkX11", "4.0")
     main("Gsk") # and two new ones for gtk4
     main("Graphene")
-    main("GLib") # and the old common onces
     main("GObject")
+    main("GLib") # and the old common onces
     main("Gio")
     main("GdkPixbuf")
     main("GModule")


### PR DESCRIPTION
OS: Windows 8.1
Nim: ver1.2.6

I'm trying to wrap [libnice](https://libnice.freedesktop.org) and I will make the PR to your repo when it can build simple libnice program.
leorize told me how to generate wrapper code with gintro and I have added `main("Nice")` to `proc launch()` in `tests/gen.nim`.
I installed libnice and gobject-introspection with `pacman -S mingw-w64-libnice` and `pacman -S mingw-w64-x86_64-gobject-introspection` using msys2.
It automatically installs glib and gobject library but my system doesn't have gtk because I don't use it.
When I run `gintro/tests/gen.nim`, it generated `nim_gi/nice.nim` and it looks like libnice was wrapped correctly.
(But I found I need to add some code to nim_gi/nice.nim and I'm trying to fix now)
But `tests/gen.nim` generates `const GobjectLib* = ""` in glib.nim and uses dynlib pragma with empty string.
When a proc with dynlib pragma with empty string is used in nim code, it just output "could not load:" and quit.
(I think using dynlib pragma with empty string should be compile error)
Such bug is hard to fix.
Root of this problem is `main` proc calls `gi.gIrepositoryGetSharedLibrary("GObject")` if namespace == "GLib" but it returns nil.
This doc says "The namespace must have already been loaded using a function such as g_irepository_require() before calling this function".
https://developer.gnome.org/gi/stable/GIRepository.html#g-irepository-get-shared-library
I think if gtk library was installed main("Gtk") was called, "GObject" namespace is automatically loaded and gi.gIrepositoryGetSharedLibrary("GObject") returns valid pointer.
In my case, gtk is not installed and "GObject" namespace is not loaded.
I fixed it by calling `main("GObject")` before `main("GLib")`.

Here is how to reproduce this problem on the system only glib and gobject-introspection are installed.
```
git clone https://github.com/StefanSalewski/gintro
cd gintro/tests
copy gir.nim glib.nim gobject.nim from oldgtk3
nim c gen.nim
mkdir nim_gi
gen.exe
```

Output:
```
Generating bindings for GTK3...
Failed to load Gtk
Typelib file for namespace 'Gtk', version '3.0' not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Gdk
Typelib file for namespace 'Gdk', version '3.0' not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load GdkX11
Typelib file for namespace 'GdkX11', version '3.0' not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Graphene
Typelib file for namespace 'Graphene' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...

** (process:8916): CRITICAL **: 04:41:43.926: g_irepository_get_shared_library: assertion 'typelib != NULL' failed
glib....................: Remaining delayed methods: 0 (Fine!)
Caution: No free/unref found for   (g_enum_complete_type_info)
Caution: No free/unref found for   (g_flags_complete_type_info)
gobject.................: Remaining delayed methods: 0 (Fine!)
gio.....................: Remaining delayed methods: 0 (Fine!)
Failed to load GdkPixbuf
Typelib file for namespace 'GdkPixbuf' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
gmodule.................: Remaining delayed methods: 0 (Fine!)
Failed to load GtkSource
Typelib file for namespace 'GtkSource' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Atk
Typelib file for namespace 'Atk' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Pango
Typelib file for namespace 'Pango' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load PangoCairo
Typelib file for namespace 'PangoCairo' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load PangoFT2
Typelib file for namespace 'PangoFT2' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
fontconfig..............: Remaining delayed methods: 0 (Fine!)
freetype2...............: Remaining delayed methods: 0 (Fine!)
Failed to load HarfBuzz
Typelib file for namespace 'HarfBuzz' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Rsvg
Typelib file for namespace 'Rsvg' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
xlib....................: Remaining delayed methods: 0 (Fine!)
Failed to load Vte
Typelib file for namespace 'Vte' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Notify
Typelib file for namespace 'Notify' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Gst
Typelib file for namespace 'Gst' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...
Failed to load Handy
Typelib file for namespace 'Handy' (any version) not found
Maybe for your OS you have to install additional GTK related packages?
We continue with the remaining packages...

** (process:8916): WARNING **: 04:41:52.883: Failed to load shared library 'libcairo-gobject-2.dll' referenced by the typelib: '
libcairo-gobject-2.dll': Specified module was not found.
cairo...................: Remaining delayed methods: 0 (Fine!)
```
