### PR TITLE
Prevent Compile Error + Cosmetics

### DIFF
--- a/tests/gen.nim
+++ b/tests/gen.nim
@@ -445,7 +445,7 @@ privStr.incl("pad")
 privStr.incl("unused")
 privStr.incl("privateData")
 
-# These objects are plain structs like GtkTextIter containing only findamental data types like uint32.
+# These objects are plain structs like GtkTextIter containing only fundamental data types like uint32.
 # They are generally allocated on the stack, so there is no alloc or free function offered by gtk.
 # If all these conditions are met, then we do not need a proxy object. Caution, some objects like
 # TextAttribute has bitfields, which is difficult to map to Nim. Watch for cstrings too!

--- a/tests/gen.nim
+++ b/tests/gen.nim
@@ -3811,10 +3811,10 @@ proc cstringArrayToSeq*(s: ptr cstring): seq[string] =
       if n[0] != '_' and not n.endsWith("Private") and not (namespace == "Gdk" and n.startsWith("Event")) and not (namespace ==
           "Pango" and n.startsWith("Attribute")):
         if gBaseInfoGetType(info) == GIInfoType.STRUCT:
-          if not ((gStructInfoIsGtypeStruct(info) and n != "ObjectClass")):
+          if not (gStructInfoIsGtypeStruct(info) or (n == "ObjectClass")):
             var lightObj = true
-            for n in "free unref  get_qdata".split:
-              if gStructInfoFindMethod(info, n) != nil:
+            for m in "free unref  get_qdata".split:
+              if gStructInfoFindMethod(info, m) != nil:
                 lightObj = false
             if lightObj:
               for j in 0.cint ..< gStructInfoGetNMethods(info):


### PR DESCRIPTION
This pull request fixes issues https://github.com/StefanSalewski/gintro/issues/151, https://github.com/StefanSalewski/gintro/issues/166 and https://github.com/StefanSalewski/gintro/issues/176:
- 3814: `nimble install gintro` failed in Debian 10 (and Ubuntu 18.04 LTS) because `GtypeStruct` and `ObjectClass` were called together. The change filters out both.

Cosmetics:
- 3816-3817: The name of a local iteration variable was changed from `n` to `m` for code clarity (it's not the same "n" as in line 3814).
- 448: Fixed spelling in a comment.