### PR TITLE
prototype gobject wrapper

### DIFF
--- a/gintro/gobjectWrapper.c
+++ b/gintro/gobjectWrapper.c
@@ -1,0 +1,18 @@
+#include "gobjectWrapper.h"
+
+G_DEFINE_TYPE(GObjectWrapper, gobject_wrapper, G_TYPE_OBJECT)
+
+static void gobject_wrapper_class_init(GObjectWrapperClass *klass)
+{
+}
+
+static void gobject_wrapper_init(GObjectWrapper *self)
+{
+}
+
+GObjectWrapper *gobject_wrapper_new(void *data)
+{
+    GObjectWrapper *self = g_object_new(GOBJECT_TYPE_WRAPPER, NULL);
+    self->data = data;
+    return self;
+}

--- a/gintro/gobjectWrapper.h
+++ b/gintro/gobjectWrapper.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define GOBJECT_TYPE_WRAPPER gobject_wrapper_get_type()
+G_DECLARE_FINAL_TYPE (GObjectWrapper, gobject_wrapper, GOBJECT, WRAPPER, GObject)
+
+struct _GObjectWrapper {
+    GObject parent_instance;
+    char* data;
+};
+
+GObjectWrapper *gobject_wrapper_new(void *data);
+
+G_END_DECLS

--- a/gintro/gobjectWrapper.nim
+++ b/gintro/gobjectWrapper.nim
@@ -1,0 +1,37 @@
+{.compile: "gobjectWrapper.c", 
+  passc: gorge("pkg-config gobject-2.0 --cflags"),
+  passl: gorge("pkg-config gobject-2.0 --libs")
+  .}
+
+import std/macros
+
+type
+  InternalGObjectWrapper[T] {.importc: "GObjectWrapper", header: "gobjectWrapper.h".} = object
+    data: pointer
+
+  GObjectWrapper*[T] = ptr InternalGObjectWrapper[T]
+
+proc internalGObjectWrapperNew(data: pointer): pointer {.importc: "gobject_wrapper_new", header: "gobjectWrapper.h".}
+
+macro gobjectWrapperNew*(data: typed): untyped =
+  let dataType = getTypeInst(data)
+  result = quote do:
+    when `data` is (ref or ptr):
+      let internal: pointer = internalGObjectWrapperNew(cast[pointer](`data`))
+    else:
+      let reffed: ref `dataType` = new(ref `dataType`) # maybe we should create a ptr instead ref here?
+      reffed[] = `data`
+      GC_ref(reffed)
+      let internal: pointer = internalGObjectWrapperNew(cast[pointer](reffed))
+    cast[GObjectWrapper[`dataType`]](internal)
+
+proc gobjectWrapperGetData*[T](wrapper: GObjectWrapper[T]): var T =
+  when T is (ref or ptr):
+    result = cast[T](wrapper.data)
+  else:
+    result = cast[ref T](wrapper.data)[]
+
+var five = 5
+
+let gobectWrapper = gobjectWrapperNew(five)
+echo gobectWrapper.gobjectWrapperGetData()


### PR DESCRIPTION
Hi there. I have written a quick and mostly untested gobject wrapper. This type is meant to allow you to put any Nim type in the place where you would normally give a gobject subclass. 

The implementation has two sides: the Nim side and the C side. The C side is simple. It is only a subclass of gobject with a single void pointer. On the Nim side, we have the datatype that mirrors the C struct and two support functions. The first takes any Nim type and, if it is not already a ref or ptr, makes a ref and calls GC_ref(). Then it casts to a pointer and passes this to the C object constructor. The other function simply takes the wrapper and casts the pointer back to the original nim datatype and derefs if necessary. 

I only need to do one thing, which is to make the wrapper compatible with how gobjects are handled in gintro. I'm not quite sure of how to do this, since gintro uses custom proxy objects, and I'm not super familiar with how those are implemented yet. Some help is required for further development. 